### PR TITLE
Pttb 232 already registered user should not be sent invitation mail

### DIFF
--- a/app/Http/Requests/MemberInviteRequest.php
+++ b/app/Http/Requests/MemberInviteRequest.php
@@ -25,7 +25,7 @@ class MemberInviteRequest extends FormRequest
     {
         return [
             'name' => 'required|regex:/^[\pL\s\-]+$/u|max:255',
-            'email' => 'required | email |max:255|unique:invite_tokens',
+            'email' => 'required | email |max:255|unique:invite_tokens|unique:users',
             'role_id' => 'required | integer|max:255',
             'user_id' => 'required | integer'
         ];

--- a/app/Http/Requests/UserStoreRequest.php
+++ b/app/Http/Requests/UserStoreRequest.php
@@ -29,6 +29,7 @@ class UserStoreRequest extends FormRequest
             'email' => 'required | email|max:255 |unique:users',
             'password' => [
                 'required',
+                'max:30',
                 Password::min(6)
                     ->mixedCase()
                     ->numbers()

--- a/app/Http/Requests/UserStoreRequest.php
+++ b/app/Http/Requests/UserStoreRequest.php
@@ -29,7 +29,7 @@ class UserStoreRequest extends FormRequest
             'email' => 'required | email|max:255 |unique:users',
             'password' => [
                 'required',
-                Password::min(8)
+                Password::min(6)
                     ->mixedCase()
                     ->numbers()
                     ->symbols()

--- a/app/Http/Requests/UserStoreRequest.php
+++ b/app/Http/Requests/UserStoreRequest.php
@@ -25,8 +25,8 @@ class UserStoreRequest extends FormRequest
     {
         return [
             'name' => 'required|regex:/^[\pL\s\-]+$/u|max:255',
-            'email' => 'required | email|max:255',
-            'password' => ['required','min:6','regex:/^.*(?=.{3,})(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[\d\x])(?=.*[!$#%]).*$/','confirmed'],
+            'email' => 'required | email|max:255 |unique:users',
+            'password' => ['required', 'min:6', 'regex:/^.*(?=.{3,})(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[\d\x])(?=.*[!$#%]).*$/', 'confirmed'],
             'token' => 'required'
         ];
     }

--- a/app/Http/Requests/UserStoreRequest.php
+++ b/app/Http/Requests/UserStoreRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
 
 class UserStoreRequest extends FormRequest
 {
@@ -26,7 +27,15 @@ class UserStoreRequest extends FormRequest
         return [
             'name' => 'required|regex:/^[\pL\s\-]+$/u|max:255',
             'email' => 'required | email|max:255 |unique:users',
-            'password' => ['required', 'min:6', 'regex:/^.*(?=.{3,})(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[\d\x])(?=.*[!$#%]).*$/', 'confirmed'],
+            'password' => [
+                'required',
+                Password::min(8)
+                    ->mixedCase()
+                    ->numbers()
+                    ->symbols()
+                    ->uncompromised(),
+                'confirmed'
+            ],
             'token' => 'required'
         ];
     }


### PR DESCRIPTION
What happened: 

1. if the admin sends invitation mail to already registered user then invitation mail is still being sent to them.
2. register form request does not have register as unique in validation.
3. Password validation messages are not descriptive enough to understand and does not support some special characters. 

What should happen:

1. If the user is already a registered user then email already taken message should be sent .
2. Register form request should have email as unique in validation.
3. Password should be descriptive enough for frontend developers to understand to work with it.